### PR TITLE
Removed metrics from coming up next

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,4 @@ Coming up next
 ==============
 
 - Namecoin support, by linking a distinct image with namecore and ncdns.
-- Metrics
 - Better isolation of the certificate signing process, in a dedicated container.


### PR DESCRIPTION
With the introduction of the stats feature in fcf6cec, I thought it made sense to remove the metrics bullet point from the coming up next section.