### PR TITLE
Removing sed regression which breaks config, fixes #27

### DIFF
--- a/unbound.sh
+++ b/unbound.sh
@@ -26,7 +26,7 @@ sed \
     -e "s/@PROVIDER_NAME@/${provider_name}/" \
     -e "s/@RR_CACHE_SIZE@/${rr_cache_size}/" \
     -e "s/@THREADS@/${threads}/" \
-    -e "s/@ZONES_DIR@/${ZONES_DIR}" \
+    -e "s#@ZONES_DIR@#${ZONES_DIR}#" \
     > /opt/unbound/etc/unbound/unbound.conf << EOT
 server:
   verbosity: 1


### PR DESCRIPTION
Unbound config not generated with this sed error, leading to unbound not binding to 553.