### PR TITLE
Added Kubernetes configurations for GCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ compiled from source.
 
 Keys and certificates are automatically rotated every 12 hour.
 
+Kubernetes
+==========
+
+Kubernetes configurations are located in the `kube` directory. Currently these assume
+a persistent disk named `dnscrypt-keys` on GCE. You will need to adjust the volumes
+definition on other platforms. Once that is setup, you can have a dnscrypt server up
+in minutes.
+
+* Edit `kube/dnscrypt-init-job.yml` and change `example.com` to your desired hostname.
+* Run `kubectl create -f kube/dnscrypt-init-job.yml` to setup your keys.
+* Run `kubectl create -f kube/dnscrypt-deployment.yml` to deploy the dnscrypt server.
+* Run `kubectl create -f kube/dnscrypt-srv.yml` to expose your server to the world.
+
+To get your public key just view the logs for the `dnscrypt-init` job. The public
+IP for your server is merely the `dnscrypt` service address.
+
 Coming up next
 ==============
 

--- a/kube/dnscrypt-deployment.yml
+++ b/kube/dnscrypt-deployment.yml
@@ -1,0 +1,33 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: default
+  labels:
+    service: dnscrypt
+  name: dnscrypt
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        service: dnscrypt
+    spec:
+      containers:
+      - env:
+        image: jedisct1/unbound-dnscrypt-server
+        name: dnscrypt
+        volumeMounts:
+          - name: dnscrypt-keys
+            mountPath: /opt/dnscrypt-wrapper/etc/keys
+        command: ["/entrypoint.sh", "start"]
+        resources:
+          requests:
+            memory: "1Gi"
+      restartPolicy: Always
+      volumes:
+        - name: dnscrypt-keys
+          gcePersistentDisk:
+            pdName: dnscrypt-keys
+            fsType: ext4

--- a/kube/dnscrypt-init-job.yml
+++ b/kube/dnscrypt-init-job.yml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dnscrypt-init
+spec:
+  template:
+    metadata:
+      name: dnscrypt-init
+    spec:
+      containers:
+      - name: dnscrypt-init
+        image: jedisct1/unbound-dnscrypt-server
+        command: ["/entrypoint.sh", "init",  "-N", "example.com"]
+        volumeMounts:
+          - name: dnscrypt-keys
+            mountPath: /opt/dnscrypt-wrapper/etc/keys
+      restartPolicy: Never
+      volumes:
+        - name: dnscrypt-keys
+          gcePersistentDisk:
+            pdName: dnscrypt-keys
+            fsType: ext4

--- a/kube/dnscrypt-srv.yml
+++ b/kube/dnscrypt-srv.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dnscrypt
+  namespace: default
+spec:
+  ports:
+    - port: 443
+      targetPort: 443
+  selector:
+    service: dnscrypt
+  type: LoadBalancer


### PR DESCRIPTION
Added configuration files for Kubernetes and documentation for the README.

Takes just a few minutes to setup.
* Create persistent disk called `dnscrypt-keys`
* Edit `kube/dnscrypt-init-job.yml` and change `example.com` to your desired hostname.
* Run `kubectl create -f kube/dnscrypt-init-job.yml` to setup your keys.
* Run `kubectl create -f kube/dnscrypt-deployment.yml` to deploy the dnscrypt server.
* Run `kubectl create -f kube/dnscrypt-srv.yml` to expose your server to the world.