### PR TITLE
Add UDP support to Kubernetes configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ a persistent disk named `dnscrypt-keys` on GCE. You will need to adjust the volu
 definition on other platforms. Once that is setup, you can have a dnscrypt server up
 in minutes.
 
+* Create a static IP on GCE. This will be used for the LoadBalancer.
 * Edit `kube/dnscrypt-init-job.yml` and change `example.com` to your desired hostname.
+* Edit `kube/dnscrypt-srv.yml` and change `loadBalancerIP` to your static IP.
 * Run `kubectl create -f kube/dnscrypt-init-job.yml` to setup your keys.
 * Run `kubectl create -f kube/dnscrypt-deployment.yml` to deploy the dnscrypt server.
 * Run `kubectl create -f kube/dnscrypt-srv.yml` to expose your server to the world.

--- a/kube/dnscrypt-srv.yml
+++ b/kube/dnscrypt-srv.yml
@@ -1,12 +1,29 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: dnscrypt
+  name: dnscrypt-tcp
   namespace: default
 spec:
   ports:
-    - port: 443
+    - protocol: TCP
+      port: 443
       targetPort: 443
   selector:
     service: dnscrypt
   type: LoadBalancer
+  loadBalancerIP: 0.0.0.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dnscrypt-udp
+  namespace: default
+spec:
+  ports:
+    - protocol: UDP
+      port: 443
+      targetPort: 443
+  selector:
+    service: dnscrypt
+  type: LoadBalancer
+  loadBalancerIP: 0.0.0.0


### PR DESCRIPTION
This adds full UDP support to the configs I submitted earlier. Now TCPOnly is not required. =)