### PR TITLE
dnscrypt-wrapper.sh update for ipv6

### DIFF
--- a/dnscrypt-wrapper.sh
+++ b/dnscrypt-wrapper.sh
@@ -60,7 +60,7 @@ prune
 
 exec /opt/dnscrypt-wrapper/sbin/dnscrypt-wrapper \
     --user=_dnscrypt-wrapper \
-    --listen-address=0.0.0.0:443 \
+    --listen-address=[::]:443 \
     --resolver-address=127.0.0.1:553 \
     --provider-name="$provider_name" \
     --provider-cert-file="$(stcerts_files)" \


### PR DESCRIPTION
This change enables the docker container to listen on ipv4 and ipv6