### PR TITLE
install linux-headers to fix missing linux/types.h during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM jedisct1/alpine-runit:latest
 MAINTAINER Frank Denis
 ENV SERIAL 2
 
-ENV BUILD_DEPS   make gcc musl-dev git libevent-dev expat-dev shadow autoconf file openssl-dev byacc
+ENV BUILD_DEPS   make gcc musl-dev git libevent-dev expat-dev shadow autoconf file openssl-dev byacc linux-headers
 ENV RUNTIME_DEPS bash util-linux coreutils findutils grep openssl ldns ldns-tools libevent expat libexecinfo coreutils drill ca-certificates
 
 RUN set -x && \


### PR DESCRIPTION
I couldn't build latest version without [linux-headers](https://pkgs.alpinelinux.org/package/edge/main/x86/linux-headers) 

```shell
docker -v
Docker version 18.09.0, build 4d60db4

docker build -t dnscrypt-server:2019.03.23 .
...
+ make install
...
libtool: compile:  gcc -I. -DSRCDIR=. -g -O2 -flto -c compat/getentropy_linux.c  -fPIC -DPIC -o .libs/getentropy_linux.o
compat/getentropy_linux.c:56:25: fatal error: linux/types.h: No such file or directory
 #include <linux/types.h>
                         ^
compilation terminated.
make: *** [Makefile:286: getentropy_linux.lo] Error 1
```