### PR TITLE
Removed --net=host as default for the docker container

### DIFF
--- a/scripts/install-centos.sh
+++ b/scripts/install-centos.sh
@@ -41,14 +41,14 @@ if [ -f /etc/dnscrypt-server/keys/state/encrypted-dns.state ]; then
         --ulimit nofile=90000:90000 \
         -v /etc/dnscrypt-server/keys:/opt/encrypted-dns/etc/keys \
         -v /etc/dnscrypt-server/lists:/opt/encrypted-dns/etc/lists \
-        --name=dnscrypt-server -p 443:443/udp -p 443:443/tcp --net=host \
+        --name=dnscrypt-server -p 443:443/udp -p 443:443/tcp \
         -d jedisct1/dnscrypt-server start
 else
     docker run \
         --ulimit nofile=90000:90000 \
         -v /etc/dnscrypt-server/keys:/opt/encrypted-dns/etc/keys \
         -v /etc/dnscrypt-server/lists:/opt/encrypted-dns/etc/lists \
-        --name=dnscrypt-server -p 443:443/udp -p 443:443/tcp --net=host \
+        --name=dnscrypt-server -p 443:443/udp -p 443:443/tcp \
         jedisct1/dnscrypt-server init -N "$SERVER" -E "${SERVER_IP}:443"
     docker start dnscrypt-server
 fi


### PR DESCRIPTION
Removed --net=host as default for the docker container
It does forward port 443 tcp/udp to the host, but it also had "--net=host" when starting. That defeats the purpose of the port forward.
Removing "--net=host" as it is also in line with the rest of the documentation.